### PR TITLE
Kenton location zeros

### DIFF
--- a/Autonomous/libs/ARTracker.cpp
+++ b/Autonomous/libs/ARTracker.cpp
@@ -80,9 +80,42 @@ int ARTracker::findARTags(int id1, int id2)
     else 
     {
         //NOTE: Distance does not matter if we're trying to drive between the posts so I ignored it here
+        int width1 = Markers[id1Index][1].x - Markers[id1Index][0].x;
+        int width2 = Markers[id2Index][1].x - Markers[id2Index][0].x;
+
+        float distance1 = (20 * focalLength) / width1;
+        float distance2 = (20 * focalLength) / width2;
+        int fartherIndex;
+        int closerIndex;
+        if(distance1 > distance2)
+        {
+            fartherIndex = id1Index;
+            closerIndex = id2Index;
+        }
+        else
+        {
+            fartherIndex = id2Index;
+            closerIndex = id1Index;
+        }
+
+        float distDiff = std::abs(distance2 - distance1);
+        float avgDist = (distance1 + distance2) / 2.0;
+        int turningDirection;
+
+        //If it is turning in the wrong direction, switch these
+        if(Markers[closerIndex][1].x - Markers[fartherIndex][1].x > 0)
+        {
+            turningDirection = 1;
+        }
+        else
+        {
+            turningDirection = -1;
+        }
         
         centerXTag = (Markers[id1Index][1].x + Markers[id1Index][0].x + Markers[id2Index][1].x + Markers[id2Index][0].x) / 4; //takes the average of all four x edges of the markers. Could probably cut this to two
-        angleToAR = degreesPerPixel * (centerXTag - 320); //takes the pixels from the tag to the center of the image and multiplies it by the degrees per pixel
+        //Adjust the coefficient of distDiff if it is turning too much or too little
+        angleToAR = degreesPerPixel * (centerXTag - 320) +
+            turningDirection * (differenceParameter * distDiff * std::pow(distanceParameter, -1 * avgDist)); //takes the pixels from the tag to the center of the image and multiplies it by the degrees per pixel
         
         return Markers.size();
     }

--- a/Autonomous/libs/ARTracker.h
+++ b/Autonomous/libs/ARTracker.h
@@ -29,5 +29,5 @@ class ARTracker
         float degreesPerPixel = 82.1/640.0; // fov / horizontal resolution. Noah gave me this
         float focalLength = 611; //For cm. Found using finalFinalLength.cpp
         float differenceParameter = 0.0;
-        float distanceParameter = 0.0;
+        float distanceParameter = 1.0;
 };

--- a/Autonomous/libs/ARTracker.h
+++ b/Autonomous/libs/ARTracker.h
@@ -28,4 +28,6 @@ class ARTracker
         int centerXTag = 0;
         float degreesPerPixel = 82.1/640.0; // fov / horizontal resolution. Noah gave me this
         float focalLength = 611; //For cm. Found using finalFinalLength.cpp
+        float differenceParameter = 0.0;
+        float distanceParameter = 0.0;
 };

--- a/Autonomous/libs/Location.cpp
+++ b/Autonomous/libs/Location.cpp
@@ -56,13 +56,30 @@ void Location::updateFieldsLoop()
 	{
 		oldLatitude = latitude;
 		oldLongitude = longitude;
-        
-		latitude = pos_llh.lat;
-		longitude = pos_llh.lon;
-		height = pos_llh.height;
-		time = pos_llh.tow;
-		error = (pos_llh.h_accuracy + pos_llh.v_accuracy) / 2.0;
-		bearing = calcBearing(oldLatitude, oldLongitude, latitude, longitude);
+        if(pos_llh.lat != 0)
+		{
+			latitude = pos_llh.lat;
+		}
+		if(pos_llh.lon != 0)
+		{
+			longitude = pos_llh.lon;
+		}
+		if(pos_llh.height != 0)
+		{
+			height = pos_llh.height;
+		}
+		if(pos_llh.tow != 0)
+		{
+			time = pos_llh.tow;
+		}
+		if(pos_llh.h_accuracy != 0 && pos_llh.v_accuracy != 0)
+		{
+			error = (pos_llh.h_accuracy + pos_llh.v_accuracy) / 2.0;
+		}
+		if(oldLatitude != latitude || oldLongitude != longitude)
+		{
+			bearing = calcBearing(oldLatitude, oldLongitude, latitude, longitude);
+		}
 
 		std::this_thread::sleep_for(std::chrono::seconds(waitDuration));
 	}


### PR DESCRIPTION
Implemented turning to correct angle when attempting to drive between two poles. The parameters distanceParameter and differenceParameter must be tuned for this to work correctly. Also added conditionals to prevent Location fields from updating if the swift gives them Zero values.